### PR TITLE
Master

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ credentials and calls `done` providing a user that is attached to `req.user`.
 
 ```js
 passport.use(new KeystoneStrategy({
-   region: your.region, // required
-   authUrl: your.authUrl, // required
-   usernameField: 'username', // optional
-   passwordField: 'password' // optional
+    authUrl: your.authUrl, // required
+    usernameField: 'username', // optional
+    passwordField: 'password' // optional
+    region: your.region, // optional
+    tenantId: your.tenantId // optional
   },
   function(user, done) {
     var user = {
@@ -45,10 +46,11 @@ The following example uses `passReqToCallback` to send the `req` object to next 
 
 ```js
 passport.use(new KeystoneStrategy({
-    region: your.region, // required
     authUrl: your.authUrl, // required
     usernameField: 'username', // optional
     passwordField: 'password' // optional
+    region: your.region, // optional
+    tenantId: your.tenantId // optional
     passReqToCallback : true // allows us to interact with req object
 }, function(req, identity, done) {
   if (!req.user) {

--- a/lib/passport-keystone/strategy.js
+++ b/lib/passport-keystone/strategy.js
@@ -55,6 +55,7 @@ function Strategy(options, verify) {
   this._passwordField = options.passwordField || 'password';
   this._region = options.region || '';
   this._authUrl = options.authUrl || '';
+  this._tenantId = options.tenantId || '';
 
   passport.Strategy.call(this);
   this.name = 'keystone';
@@ -97,6 +98,7 @@ Strategy.prototype.authenticate = function(req, options) {
   config.password = lookup(req.body, this._passwordField) || lookup(req.query, this._passwordField);
   config.authUrl = this._authUrl;
   config.region = this._region;
+  config.tenantId = this._tenantId;
 
   if (!config.username || !config.password) {
     return this.fail({ message: options.badRequestMessage || 'Missing credentials' }, 400);
@@ -106,11 +108,6 @@ Strategy.prototype.authenticate = function(req, options) {
   if (!config.authUrl) {
     return this.fail({ message: options.badRequestMessage || 'Missing Identity Endpoint' }, 400);
   }
-  if (!config.region) {
-    return this.fail({ message: options.badRequestMessage || 'Missing Identity Region' }, 400);
-  }
-
-
 
   var verified = function(self) {
     // Callback given to user given verify function.


### PR DESCRIPTION
added tenantId as an option. Also made region not required parameter since it seems like the param is Rackspace specific.  http://developer.openstack.org/api-ref-identity-v2.html. region isn’t required at all for tokens API.
